### PR TITLE
Fix Telegram Video Embeds

### DIFF
--- a/InstagramEmbedForDiscord/Controllers/HomeController.cs
+++ b/InstagramEmbedForDiscord/Controllers/HomeController.cs
@@ -77,7 +77,7 @@ namespace InstagramEmbedForDiscord.Controllers
                 if (string.IsNullOrWhiteSpace(path))
                     return BadRequest("Invalid Instagram path.");
 
-                bool scrapeForPostInfomration = Request.Host.Host.EndsWith("d.vxinstagram.com", StringComparison.OrdinalIgnoreCase);
+                bool scrapeForPostInfomration = Request.Host.Host.StartsWith("d.", StringComparison.OrdinalIgnoreCase);
 
                 var segments = path.Trim('/').Split('/');
 
@@ -261,6 +261,8 @@ namespace InstagramEmbedForDiscord.Controllers
 
         [Route("/offload/{id}/{order?}")]
         [Route("/offload/{id}")]
+        [Route("/offload/{id}.mp4")]
+        [Route("/offload/{id}/{order}.mp4")]
         public async Task<IActionResult> OffloadPost(string id, int? order, bool? thumbnail = false)
         {
             int orderIndex = (order ?? 0);
@@ -281,12 +283,44 @@ namespace InstagramEmbedForDiscord.Controllers
             if (entry == null)
                 return NotFound();
 
+            string targetUrl = entry.RapidSaveUrl;
             if (thumbnail ?? false)
             {
-                return Redirect(entry.MediaType == "video" ? post.DefaultThumbnailUrl ?? entry.ThumbnailUrl : entry.ThumbnailUrl);
+                targetUrl = entry.MediaType == "video" ? post.DefaultThumbnailUrl ?? entry.ThumbnailUrl : entry.ThumbnailUrl;
             }
 
-            return Redirect(entry.RapidSaveUrl);
+            var userAgent = Request.Headers.UserAgent.ToString();
+            if (userAgent.Contains("TelegramBot", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    using var proxyRequest = new HttpRequestMessage(HttpMethod.Get, targetUrl);
+                    proxyRequest.Headers.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36");
+
+                    var proxyResponse = await _regularClient.SendAsync(proxyRequest, HttpCompletionOption.ResponseHeadersRead);
+                    if (proxyResponse.IsSuccessStatusCode)
+                    {
+                        var stream = await proxyResponse.Content.ReadAsStreamAsync();
+                        var contentType = proxyResponse.Content.Headers.ContentType?.MediaType;
+
+                        if (string.IsNullOrWhiteSpace(contentType))
+                        {
+                            contentType = entry.MediaType == "video" ? "video/mp4" : "application/octet-stream";
+                        }
+
+                        HttpContext.Response.RegisterForDispose(proxyResponse);
+                        return File(stream, contentType, enableRangeProcessing: true);
+                    }
+
+                    proxyResponse.Dispose();
+                }
+                catch
+                {
+                    // Fall back to redirect if Telegram proxying fails.
+                }
+            }
+
+            return Redirect(targetUrl);
 
         }
 

--- a/InstagramEmbedForDiscord/Views/Home/Index.cshtml
+++ b/InstagramEmbedForDiscord/Views/Home/Index.cshtml
@@ -7,6 +7,7 @@
     string thumbnailUrl = Model[1];
     string url = Model[2];
     bool isPhoto = ViewBag.IsPhoto;
+    bool isTelegram = Context.Request.Headers.UserAgent.ToString().Contains("TelegramBot", StringComparison.OrdinalIgnoreCase);
 
     string postId = ViewBag.PostID;
     int order = ViewBag.Order ?? 1;
@@ -19,14 +20,30 @@
         contentUrl = $"{baseUrl}/offload/{postId}/{order}/";
     }
 
-    // int width = ViewBag.Width ?? 0;
-    // int height = ViewBag.Height ?? 0;
+    if (!isPhoto && !contentUrl.EndsWith(".mp4", StringComparison.OrdinalIgnoreCase))
+    {
+        contentUrl = $"{contentUrl.TrimEnd('/')}.mp4";
+    }
 
     Post post = ViewBag.Post;
+    int width = post?.Width > 0 ? post.Width : 720;
+    int height = post?.Height > 0 ? post.Height : 1280;
+
+    if (width > 1920 || height > 1920)
+    {
+        width /= 2;
+        height /= 2;
+    }
+
+    if (width < 400 && height < 400)
+    {
+        width *= 2;
+        height *= 2;
+    }
 
     List<InstagramMedia> files = ViewBag.Files ?? new List<InstagramMedia>();
 
-    if (!Context.Request.Host.Host.EndsWith("d.vxinstagram.com", StringComparison.OrdinalIgnoreCase))
+    if (!Context.Request.Host.Host.StartsWith("d.", StringComparison.OrdinalIgnoreCase))
     {
         post.AuthorUsername = null;
         post.Caption = null;
@@ -68,11 +85,20 @@
     {
         <meta property="og:type" content="video.other" />
         <meta property="og:video" content="@contentUrl" />
-
         <meta property="og:video:secure_url" content="@contentUrl" />
         <meta property="og:video:type" content="video/mp4" />
-        <meta name="twitter:player" content="@url" />
-        <meta name="twitter:card" content="video.other" />
+        <meta property="og:video:width" content="@width" />
+        <meta property="og:video:height" content="@height" />
+
+        <meta name="twitter:player:stream" content="@contentUrl" />
+        <meta name="twitter:player:width" content="@width" />
+        <meta name="twitter:player:height" content="@height" />
+        <meta name="twitter:card" content="player" />
+
+        @if (!isTelegram)
+        {
+            <meta name="twitter:player" content="@url" />
+        }
 
     }
     


### PR DESCRIPTION
## Summary
This PR improves media embedding behavior for social platforms by fixing Telegram native video playback and making metadata scraping work with custom domains that use the d. subdomain pattern. Fixes #2.

## Why this change
Instagram CDN links can return 403 for bot traffic, which breaks Telegram native playback in some cases.  
At the same time, metadata scraping was tied to a single hardcoded domain, so custom domains could not use the full scraping path.

## What was changed

### 1. Telegram native video embedding fix
- Added direct MP4 offload routes:
  - /offload/{id}.mp4
  - /offload/{id}/{order}.mp4
- Updated offload behavior for Telegram:
  - Detect TelegramBot via User-Agent.
  - When Telegram is detected, proxy media through the backend instead of redirecting.
  - Fetch media with a browser-like User-Agent to bypass Instagram CDN blocking behavior.
  - Return streamed file content with range processing enabled for better native player compatibility.
  - If proxying fails (or client is not Telegram), fall back to the existing redirect behavior.

### 2. Custom domain scraping support
- Replaced hardcoded d.vxinstagram.com checks with a generic host prefix check:
  - from strict domain suffix matching
  - to host starts with d.
- This enables metadata scraping and post-detail logic on custom domains such as d.my-domain.com.

### 3. Video metadata improvements for platform compatibility
- Added Telegram-aware rendering in the page metadata layer.
- For non-photo content, ensure media URL ends with .mp4.
- Added/updated video metadata tags for player compatibility:
  - og:video
  - og:video:secure_url
  - twitter:player:stream
  - og:video:width
  - og:video:height
  - twitter:player:width
  - twitter:player:height
  - twitter:card set to player
- Kept twitter:player only for non-Telegram requests so:
  - Discord still receives the large player behavior.
  - Telegram can use native playback without conflicting card behavior.

### 4. Safe video dimension boundaries
- Added robust width/height defaults and normalization:
  - default values: 720 x 1280 when missing
  - if either dimension is above 1920, both are halved
  - if both dimensions are below 400, both are doubled

## Local testing
Tested locally in Docker using a custom domain setup with a vx. subdomain.

Validation performed:
- Telegram native playback works for video embeds.
- Telegram receives playable stream metadata and MP4 URLs.
- Discord behavior remains compatible (large player path preserved for non-Telegram).
- Custom d. domain correctly triggers metadata scraping path.
- Fallback redirect still works when proxying is not used or fails.